### PR TITLE
[3532724049] fix blend shape weight range

### DIFF
--- a/Runtime/Extras/VoiceHandler.cs
+++ b/Runtime/Extras/VoiceHandler.cs
@@ -30,8 +30,6 @@ namespace ReadyPlayerMe.AvatarLoader
         private SkinnedMeshRenderer beardMesh;
         private SkinnedMeshRenderer teethMesh;
 
-        private const float MOUTH_OPEN_MULTIPLIER = 100f;
-
         private int mouthOpenBlendShapeIndexOnHeadMesh = -1;
         private int mouthOpenBlendShapeIndexOnBeardMesh = -1;
         private int mouthOpenBlendShapeIndexOnTeethMesh = -1;
@@ -159,7 +157,7 @@ namespace ReadyPlayerMe.AvatarLoader
             {
                 if (index >= 0)
                 {
-                    mesh.SetBlendShapeWeight(index, weight * MOUTH_OPEN_MULTIPLIER);
+                    mesh.SetBlendShapeWeight(index, weight);
                 }
             }
         }


### PR DESCRIPTION
## [3532724049](https://ready-player-me.monday.com/boards/3205996800/views/73153347/pulses/3532724049)

## Description

- glTFast generates blend shapes with range [0-1]
- voice handler extra needs updating to cater for this


## Changes

#### Updated

-   Voice Handler script updated to no longer apply multiplier for blend shapes range [0-100]

<!-- Testability -->

## How to Test

- Load an avatar using a new avatar api url and an older cloudfront url - with voice handler enabled
- Observe blend shape range 0-1 in skinned mesh renderer
- play scene and observe mouth shapes are not breaking due to 0-100 values being applied to 0-1 control range

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



